### PR TITLE
Fix for showing last message in contact list

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/README.md
+++ b/README.md
@@ -15,3 +15,9 @@ In this project **Dragonfly**, I am developing a fully functional open-source ch
 ## Getting Started
 
 - for setting-up development environment read [setup-dev-environment](docs/setup-dev-environment.md).
+
+## Contributors
+
+Thanks to valuable contributors 💖
+
+- [@jitendra-ky](https://github.com/jitendra-ky)

--- a/static/js/home.js
+++ b/static/js/home.js
@@ -168,7 +168,8 @@ function rerender_contacts_view() {
         const profile = $('<div>').addClass('chat-item-profile')
         const details = $('<div>').addClass('chat-item-details')
         details.append($('<h4>').text(contact.email))
-        details.append($('<p>').text('Hey, how are you?'))
+        // Append the actual last message from the contact if available, otherwise show a default message
+        details.append($('<p>').text(contact.last_message || 'No messages yet'))
         contactContent.append(profile, details)
         contactElement.append(contactContent)
         chatList.append(contactElement)

--- a/zserver/serializers/user_profile.py
+++ b/zserver/serializers/user_profile.py
@@ -1,10 +1,20 @@
+from django.db.models import Q  # Import Q object for building complex queries using OR conditions
 from rest_framework import serializers
 
-from zserver.models import Session, SignUpOTP, UnverifiedUserProfile, UserProfile, VerifyUserOTP
+from zserver.models import (
+    Message,
+    Session,
+    SignUpOTP,
+    UnverifiedUserProfile,
+    UserProfile,  #add Message Model
+    VerifyUserOTP,
+)
 
 
 # Serializer class for the UserProfile model
 class UserProfileSerializer(serializers.ModelSerializer):
+    # Add dynamic field for last message between the user and the contact
+    last_message = serializers.SerializerMethodField()
     class Meta:
         """Meta class to specify the model and fields to be serialized."""
 
@@ -14,10 +24,26 @@ class UserProfileSerializer(serializers.ModelSerializer):
             "fullname",
             "email",
             "password",
+            "last_message",
         ]  # Fields to be included in the serialization
         extra_kwargs = {
             "password": {"write_only": True},  # Make the password field write-only
         }
+
+    def get_last_message(self, contact: UserProfile) -> str:
+        """Retrieve the last message exchanged with the given contact."""
+        # Get the authenticated user from serializer context
+        user = self.context.get("user")
+        if not user:
+            return None
+
+        # Fetch the latest message between user and this contact
+        last_msg = Message.objects.filter(
+            Q(sender=user, receiver=contact) | Q(sender=contact, receiver=user),
+        ).order_by("-timestamp").first()
+
+        # Return message text if available, else None
+        return last_msg.content if last_msg else "No messages yet"
 
     def update(self, instance: UserProfile, validated_data: dict) -> UserProfile:
         """Update an existing user profile."""

--- a/zserver/views/message.py
+++ b/zserver/views/message.py
@@ -67,7 +67,8 @@ class ContactView(APIView):
         contacts_sender = { msg.receiver for msg in Message.objects.filter(sender=user) }
         contacts_receiver = { msg.sender for msg in Message.objects.filter(receiver=user) }
         contacts = contacts_sender.union(contacts_receiver)
-        serializer = UserProfileSerializer(contacts, many=True)
+        # With this one — pass the authenticated user via context for custom field logic
+        serializer = UserProfileSerializer(contacts, many=True, context={"user": user})
         return Response(serializer.data)
 
 


### PR DESCRIPTION
🛠️ Fix: Show last message in contact list
❗ Problem
In the original view, the list of contacts was returned using UserProfileSerializer, but there was no way to display the last message exchanged between the authenticated user and each contact. This made the contact list feel static and less informative.

✅ Solution
Added a new dynamic field last_message to the UserProfileSerializer using SerializerMethodField.

The get_last_message method uses a Q filter to find the latest message between the authenticated user and each contact.

If there’s no message between the user and a contact, it returns "No messages yet" as default.

💻 Frontend Update
In the frontend code, instead of showing a hardcoded text ("Hey, how are you?"), it now shows the actual contact.last_message value or "No messages yet" if none is available.

details.append($('<p>').text(contact.last_message || 'No messages yet'))